### PR TITLE
Sets cache override and expiry within CDN. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Terraform
 *.plan
+*.out
 .terraform
 *.variables.tf
 *.tfstate

--- a/terraform/progression.tf
+++ b/terraform/progression.tf
@@ -44,6 +44,13 @@ resource "azurerm_cdn_endpoint" "progressionframework-cdn-endpoint" {
     is_http_allowed     = false
     origin_host_header  = azurerm_storage_account.progressionframework.primary_web_host
     optimization_type   = "GeneralWebDelivery"
+    
+    global_delivery_rule {
+        cache_expiration_action {
+            behavior = "Override"
+            duration = "00:05:00"
+        }
+    }
     is_compression_enabled = true
     content_types_to_compress = [
         "application/eot",

--- a/terraform/progression.tf
+++ b/terraform/progression.tf
@@ -15,20 +15,11 @@ resource "azurerm_storage_account" "progressionframework" {
     account_tier              = "Standard"
     account_replication_type  = "LRS"
     account_kind              = "StorageV2"
-}
 
-resource "null_resource" "azure-login" {
-  provisioner "local-exec" {
-    command = "az login --service-principal -u %ARM_CLIENT_ID% -p %ARM_CLIENT_SECRET% --tenant %ARM_TENANT_ID%"
+    static_website {
+        index_document     = "index.html"
+        error_404_document = "404.html"
     }
-  depends_on = [azurerm_storage_account.progressionframework]
-}
-
-resource "null_resource" "progression-framework-static" {
-  provisioner "local-exec" {
-    command = "az storage blob service-properties update --account-name ${azurerm_storage_account.progressionframework.name} --static-website  --index-document index.html --404-document 404.html"
-    }
-  depends_on = [null_resource.azure-login]
 }
 
 resource "azurerm_cdn_profile" "progressionframework-cdn-profile" {
@@ -38,20 +29,66 @@ resource "azurerm_cdn_profile" "progressionframework-cdn-profile" {
 
   sku                 = "Standard_Microsoft"
           
-  depends_on          = [null_resource.progression-framework-static]
+  depends_on          = [azurerm_storage_account.progressionframework]
 }
 
 resource "azurerm_cdn_endpoint" "progressionframework-cdn-endpoint" {
-  name                = "${var.webname}-cdn-endpoint"
-  profile_name        = azurerm_cdn_profile.progressionframework-cdn-profile.name
-  location            = azurerm_resource_group.rg-progression-framework.location
-  resource_group_name = azurerm_resource_group.rg-progression-framework.name
-  origin_host_header  = replace(replace(azurerm_storage_account.progressionframework.primary_web_endpoint,"https://",""),"/","")
+    name                = "${var.webname}-cdn-endpoint"
+    resource_group_name = azurerm_resource_group.rg-progression-framework.name
+
+    location            = "global"
+
+    profile_name      = azurerm_cdn_profile.progressionframework-cdn-profile.name
+    is_http_allowed   = false
+  origin_host_header  = azurerm_storage_account.progressionframework.primary_web_host
   optimization_type   = "GeneralWebDelivery"
+    is_compression_enabled = true
+    content_types_to_compress = [
+        "application/eot",
+        "application/font",
+        "application/font-sfnt",
+        "application/javascript",
+        "application/json",
+        "application/opentype",
+        "application/otf",
+        "application/pkcs7-mime",
+        "application/truetype",
+        "application/ttf",
+        "application/vnd.ms-fontobject",
+        "application/xhtml+xml",
+        "application/xml",
+        "application/xml+rss",
+        "application/x-font-opentype",
+        "application/x-font-truetype",
+        "application/x-font-ttf",
+        "application/x-httpd-cgi",
+        "application/x-javascript",
+        "application/x-mpegurl",
+        "application/x-opentype",
+        "application/x-otf",
+        "application/x-perl",
+        "application/x-ttf",
+        "font/eot",
+        "font/ttf",
+        "font/otf",
+        "font/opentype",
+        "image/svg+xml",
+        "text/css",
+        "text/csv",
+        "text/html",
+        "text/javascript",
+        "text/js",
+        "text/plain",
+        "text/richtext",
+        "text/tab-separated-values",
+        "text/xml",
+        "text/x-script",
+        "text/x-component",
+        "text/x-java-source"]
   
   origin {
     name       = "${var.webname}-${azurerm_storage_account.progressionframework.name}"
-    host_name  = replace(replace(azurerm_storage_account.progressionframework.primary_web_endpoint,"https://",""),"/","")
+    host_name  = azurerm_storage_account.progressionframework.primary_web_host
     https_port = "443"
   }
   depends_on = [azurerm_cdn_profile.progressionframework-cdn-profile]

--- a/terraform/progression.tf
+++ b/terraform/progression.tf
@@ -1,18 +1,4 @@
-terraform {
-  backend "azurerm" {
-    resource_group_name  = "RG-Terraform-State"
-    storage_account_name = "brightterraformstate"
-    container_name       = "rg-progression-framework"
-    key                  = "progression-framework.terraform.tfstate"
-  }
-}
-
-provider "azurerm" {
-    version = "=1.36.0"
-}
-
 variable "webname" {
-    type    = "string"
     default = "progression-framework"
 }
 
@@ -23,8 +9,9 @@ resource "azurerm_resource_group" "rg-progression-framework" {
 
 resource "azurerm_storage_account" "progressionframework" {
     name                      = "briprgfwk140916"
-    resource_group_name       = "${azurerm_resource_group.rg-progression-framework.name}"
-    location                  = "${azurerm_resource_group.rg-progression-framework.location}"
+    resource_group_name       = azurerm_resource_group.rg-progression-framework.name
+    location                  = azurerm_resource_group.rg-progression-framework.location
+    
     account_tier              = "Standard"
     account_replication_type  = "LRS"
     account_kind              = "StorageV2"
@@ -34,36 +21,38 @@ resource "null_resource" "azure-login" {
   provisioner "local-exec" {
     command = "az login --service-principal -u %ARM_CLIENT_ID% -p %ARM_CLIENT_SECRET% --tenant %ARM_TENANT_ID%"
     }
-  depends_on = ["azurerm_storage_account.progressionframework"]
+  depends_on = [azurerm_storage_account.progressionframework]
 }
 
 resource "null_resource" "progression-framework-static" {
   provisioner "local-exec" {
     command = "az storage blob service-properties update --account-name ${azurerm_storage_account.progressionframework.name} --static-website  --index-document index.html --404-document 404.html"
     }
-  depends_on = ["null_resource.azure-login"]
+  depends_on = [null_resource.azure-login]
 }
 
 resource "azurerm_cdn_profile" "progressionframework-cdn-profile" {
   name                = "${var.webname}-cdn-profile"
-  location            = "${azurerm_resource_group.rg-progression-framework.location}"
-  resource_group_name = "${azurerm_resource_group.rg-progression-framework.name}"
+  location            = azurerm_resource_group.rg-progression-framework.location
+  resource_group_name = azurerm_resource_group.rg-progression-framework.name
+
   sku                 = "Standard_Microsoft"
-  depends_on          = ["null_resource.progression-framework-static"]
+          
+  depends_on          = [null_resource.progression-framework-static]
 }
 
 resource "azurerm_cdn_endpoint" "progressionframework-cdn-endpoint" {
   name                = "${var.webname}-cdn-endpoint"
-  profile_name        = "${azurerm_cdn_profile.progressionframework-cdn-profile.name}"
-  location            = "${azurerm_resource_group.rg-progression-framework.location}"
-  resource_group_name = "${azurerm_resource_group.rg-progression-framework.name}"
-  origin_host_header  = replace(replace("${azurerm_storage_account.progressionframework.primary_web_endpoint}","https://",""),"/","")
+  profile_name        = azurerm_cdn_profile.progressionframework-cdn-profile.name
+  location            = azurerm_resource_group.rg-progression-framework.location
+  resource_group_name = azurerm_resource_group.rg-progression-framework.name
+  origin_host_header  = replace(replace(azurerm_storage_account.progressionframework.primary_web_endpoint,"https://",""),"/","")
   optimization_type   = "GeneralWebDelivery"
   
   origin {
     name       = "${var.webname}-${azurerm_storage_account.progressionframework.name}"
-    host_name  = replace(replace("${azurerm_storage_account.progressionframework.primary_web_endpoint}","https://",""),"/","")
+    host_name  = replace(replace(azurerm_storage_account.progressionframework.primary_web_endpoint,"https://",""),"/","")
     https_port = "443"
   }
-  depends_on = ["azurerm_cdn_profile.progressionframework-cdn-profile"]
+  depends_on = [azurerm_cdn_profile.progressionframework-cdn-profile]
 }

--- a/terraform/progression.tf
+++ b/terraform/progression.tf
@@ -1,10 +1,13 @@
-variable "webname" {
-    default = "progression-framework"
-}
-
 resource "azurerm_resource_group" "rg-progression-framework" {
     name     = "RG-Progression-Framework"
     location = "North Europe"
+    
+    tags ={
+        "Domain"      = "Personal Development"
+        "Environment" = "Prod"
+        "Product"     = "Career Framework"
+        "Territory"   = "UK"
+    }
 }
 
 resource "azurerm_storage_account" "progressionframework" {
@@ -23,25 +26,24 @@ resource "azurerm_storage_account" "progressionframework" {
 }
 
 resource "azurerm_cdn_profile" "progressionframework-cdn-profile" {
-  name                = "${var.webname}-cdn-profile"
-  location            = azurerm_resource_group.rg-progression-framework.location
-  resource_group_name = azurerm_resource_group.rg-progression-framework.name
-
-  sku                 = "Standard_Microsoft"
+    name                = "progression-framework-cdn-profile"
+    location            = azurerm_resource_group.rg-progression-framework.location
+    resource_group_name = azurerm_resource_group.rg-progression-framework.name
+    
+    sku                 = "Standard_Microsoft"
           
-  depends_on          = [azurerm_storage_account.progressionframework]
+    depends_on          = [azurerm_storage_account.progressionframework]
 }
 
 resource "azurerm_cdn_endpoint" "progressionframework-cdn-endpoint" {
-    name                = "${var.webname}-cdn-endpoint"
+    name                = "progression-framework-cdn-endpoint"
     resource_group_name = azurerm_resource_group.rg-progression-framework.name
+    location            = azurerm_resource_group.rg-progression-framework.location
 
-    location            = "global"
-
-    profile_name      = azurerm_cdn_profile.progressionframework-cdn-profile.name
-    is_http_allowed   = false
-  origin_host_header  = azurerm_storage_account.progressionframework.primary_web_host
-  optimization_type   = "GeneralWebDelivery"
+    profile_name        = azurerm_cdn_profile.progressionframework-cdn-profile.name
+    is_http_allowed     = false
+    origin_host_header  = azurerm_storage_account.progressionframework.primary_web_host
+    optimization_type   = "GeneralWebDelivery"
     is_compression_enabled = true
     content_types_to_compress = [
         "application/eot",
@@ -87,9 +89,10 @@ resource "azurerm_cdn_endpoint" "progressionframework-cdn-endpoint" {
         "text/x-java-source"]
   
   origin {
-    name       = "${var.webname}-${azurerm_storage_account.progressionframework.name}"
+    name       = "progression-framework-${azurerm_storage_account.progressionframework.name}"
     host_name  = azurerm_storage_account.progressionframework.primary_web_host
     https_port = "443"
-  }
-  depends_on = [azurerm_cdn_profile.progressionframework-cdn-profile]
+    }
+    
+    depends_on = [azurerm_cdn_profile.progressionframework-cdn-profile]
 }

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,26 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+    }
+    null = {
+      source = "hashicorp/null"
+    }
+  }
+  required_version = "= 0.13.6"
+  backend "azurerm" {
+    resource_group_name  = "RG-Terraform-State"
+    storage_account_name = "brightterraformstate"
+    container_name       = "rg-progression-framework"
+    key                  = "progression-framework.terraform.tfstate"
+  }
+}
+
+provider "azurerm" {
+  version = "=2.49.0"
+  features {}
+}
+
+provider "null" {
+  version = "=3.0.0"
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -20,7 +20,3 @@ provider "azurerm" {
   version = "=2.49.0"
   features {}
 }
-
-provider "null" {
-  version = "=3.0.0"
-}


### PR DESCRIPTION
Sets a 5 minute cache expiry for all assets within the cdn to prevent cache busting issues with gatsby.

Upgraded terraform and provider versions.
Added improvements to the resources used. 